### PR TITLE
Fix non working listener in Laravel 8

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -16,8 +16,4 @@ class EventServiceProvider extends ServiceProvider
     {
         parent::boot();
     }
-    
-    public function register()
-    {
-    }
 }


### PR DESCRIPTION
The listener was not called due to an empty register function