### PR TITLE
throw an event in case of suppression of the notification

### DIFF
--- a/src/Events/NotificationSuppressedEvent.php
+++ b/src/Events/NotificationSuppressedEvent.php
@@ -3,8 +3,8 @@
 namespace LiranCo\NotificationSubscriptions\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Queue\SerializesModels;
 
 class NotificationSuppressedEvent
 {

--- a/src/Events/NotificationSuppressedEvent.php
+++ b/src/Events/NotificationSuppressedEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace LiranCo\NotificationSubscriptions\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Notifications\Events\NotificationSending;
+
+class NotificationSuppressedEvent
+{
+    use Dispatchable, SerializesModels;
+
+    private $event;
+
+    private $notification;
+
+    private $channel;
+
+    private $model;
+
+    public function __construct(NotificationSending $event, $notification, string $channel, ?string $model)
+    {
+        $this->event = $event;
+        $this->notification = $notification;
+        $this->channel = $channel;
+        $this->model = $model;
+    }
+
+    public function getSuppressedEvent()
+    {
+        return $this->event;
+    }
+
+    public function getNotification()
+    {
+        return $this->notification;
+    }
+
+    public function getChannel()
+    {
+        return $this->channel;
+    }
+
+    public function getModel()
+    {
+        return $this->model;
+    }
+}

--- a/src/Events/NotificationSuppressedEvent.php
+++ b/src/Events/NotificationSuppressedEvent.php
@@ -8,7 +8,8 @@ use Illuminate\Notifications\Events\NotificationSending;
 
 class NotificationSuppressedEvent
 {
-    use Dispatchable, SerializesModels;
+    use Dispatchable;
+    use SerializesModels;
 
     private $event;
 

--- a/src/Listeners/NotificationSendingListener.php
+++ b/src/Listeners/NotificationSendingListener.php
@@ -2,6 +2,7 @@
 
 namespace LiranCo\NotificationSubscriptions\Listeners;
 
+use LiranCo\NotificationSubscriptions\Events\NotificationSuppressedEvent;
 use LiranCo\NotificationSubscriptions\Traits\HasNotificationSubscriptions;
 use Illuminate\Notifications\Events\NotificationSending;
 
@@ -33,7 +34,10 @@ class NotificationSendingListener
         
         $subscribed = $event->notifiable->isSubscribed(get_class($event->notification), $event->channel, $model, $optin);
          
-        if (! $subscribed) return false;
+        if (! $subscribed) {
+            NotificationSuppressedEvent::dispatch($event, $event->notification, $event->channel, $model);
+            return false;
+        }
         
         return $event;
     }


### PR DESCRIPTION
This will throw an event when the original was suppressed due to a unsubscribe. This way other parts of the system can still handle the suppressed notification, ie for logging