### PR TITLE
Correct opt-in method name in Readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $user->notify(new InvoicePaid($invoice)); //This won't get sent.
 
 By default, all notifications will be sent if no subscribe/unsubscribe record is found. This means you don't need to explicitly **subscribe** a user to a notification, you only need to **unsubscribe** them.
 
-In some cases, however, you'd like to create opt-in notifications. To do so, modify your notification class and add a function called `getOptInChannels`:
+In some cases, however, you'd like to create opt-in notifications. To do so, modify your notification class and add a function called `getOptInSubscriptions`:
 
 ```php
 <?php
@@ -90,7 +90,7 @@ class InvoicePaid extends Notification
         return ['mail', 'sms'];
     }
 
-    public function getOptInChannels()
+    public function getOptInSubscriptions()
     {
         return ['sms'];
     }


### PR DESCRIPTION
In the Readme under the [Opt-In functionality section](https://github.com/liran-co/laravel-notification-subscriptions/blob/v1.2/README.md#opt-in-notifications), it says that the method to add to the Notification is `getOptInChannels()`.

Unless I'm missing something, [based on the listener](https://github.com/liran-co/laravel-notification-subscriptions/blob/v1.2/src/Listeners/NotificationSendingListener.php#L29-L32), it looks like it should actually be `getOptInSubscriptions()`. Not sure if you were planning on changing it in a future version of the package or what, but figured I'd throw up a quick PR to correct. 