### PR TITLE
FIX: return void in handle method of the listener

### DIFF
--- a/src/Listeners/NotificationSendingListener.php
+++ b/src/Listeners/NotificationSendingListener.php
@@ -11,15 +11,15 @@ class NotificationSendingListener
     public function handle(NotificationSending $event)
     {
         if (!in_array(HasNotificationSubscriptions::class, class_uses_recursive($event->notifiable))) {
-            return $event;
+            return;
         }
 
         if (in_array($event->channel, config('notification-subscriptions.excluded_channels'))) {
-            return $event;
+            return;
         }
 
         if ($event->notification->ignoreSubscriptions ?? false) {
-            return $event;
+            return;
         }
 
         $model = null;
@@ -39,6 +39,6 @@ class NotificationSendingListener
             return false;
         }
 
-        return $event;
+        return;
     }
 }


### PR DESCRIPTION
This will fix the issue where the app cannot listen to the laravel event `NotificationSending` as the listener in the package is returning `$event` that causes the notification to be processed ignoring other listeners of the same event being called (or ignored).

Fixes #19 